### PR TITLE
add rule no-unused-expressions=off

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -38,5 +38,13 @@ module.exports = {
     {{/if_eq}}
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
-  }
+  },
+  overrides: [
+    {
+      "files": ["*-test.js", "*.spec.js"],
+      "rules": {
+        "no-unused-expressions": "off"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
some chai tests may trigger the eslint no-used-expressions
```
  ✘  http://eslint.org/docs/rules/no-unused-expressions  Expected an assignment or function call and instead saw an expression
  path/to/test.spec.js:62:9
          expect(await proxy[ID_APPARECCHIO]).to.not.be.undefined
           ^


✘ 1 problem (1 error, 0 warnings)


Errors:
  1  http://eslint.org/docs/rules/no-unused-expressions
```
the solution is a copy & paste from [Eslint docs](https://eslint.org/docs/user-guide/configuring#disabling-rules-only-for-a-group-of-files)